### PR TITLE
62479 unit tests

### DIFF
--- a/Stock.Api.sln
+++ b/Stock.Api.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stock.Model", "Stock.Model\Stock.Model.csproj", "{56F2A339-C7A1-4FF0-BBE3-FF83F454AE01}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stock.Repository.LiteDb", "Stock.Repository.LiteDb\Stock.Repository.LiteDb.csproj", "{D3AD2199-3805-45F5-B400-16C02C48A7B3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stock.Test", "Stock.Test\Stock.Test.csproj", "{1DCE5647-C174-4291-84F1-30734EA90C33}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Stock.Test/ProviderControllerTests.cs
+++ b/Stock.Test/ProviderControllerTests.cs
@@ -1,79 +1,81 @@
-//using NUnit.Framework;
-//using Stock.Api.DTOs;
-//using System;
+using NUnit.Framework;
+using Stock.Api.DTOs;
+using System;
 
-//namespace Stock.Test
-//{
-//    public class ProviderControllerTests
-//    {
-//        [Test]
-//        public void When_ProvierControllerCreated_Expect_PostMethodWithParameter()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Post";
-//            var providerDTOParameter = "Stock.Api.DTOs.ProviderDTO, Stock.Api";
-//            var parametersType = new Type[] { Type.GetType(providerDTOParameter) };
+namespace Stock.Test
+{
+    public class ProviderControllerTests
+    {
+        [Test]
+        public void When_ProvierControllerCreated_Expect_PostMethodWithParameter()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Post";
+            var providerDTOParameter = "Stock.Api.DTOs.ProviderDTO, Stock.Api";
+            var parametersType = new Type[] { Type.GetType(providerDTOParameter) };
 
-//            Assert.True(HasMethod(className, methodName, parametersType));
-//        }
+            Assert.True(HasMethod(className, methodName, parametersType));
+        }
 
-//        [Test]
-//        public void When_ProviderControllerCreated_Expect_GetMethodWhitParameter()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Get";
-//            var parametersType = new Type[] { typeof(string) };
+        [Test]
+        public void When_ProviderControllerCreated_Expect_GetMethodWhitParameter()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Get";
+            var parametersType = new Type[] { typeof(string) };
 
-//            Assert.True(HasMethod(className, methodName, parametersType));
-//        }
+            Assert.True(HasMethod(className, methodName, parametersType));
+        }
 
-//        [Test]
-//        public void When_ProviderControllerCreated_Expect_GetMethodWhitoutParameter()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Get";
+        [Test]
+        public void When_ProviderControllerCreated_Expect_GetMethodWhitoutParameter()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Get";
 
-//            Assert.True(HasMethod(className, methodName));
-//        }
+            Assert.True(HasMethod(className, methodName));
+        }
 
-//        [Test]
-//        public void When_ProviderControllerCreated_Expect_PutMethodWithTwoParameters()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Put";
-//            var parametersType = new Type[] { typeof(string), typeof(ProviderDTO) };
+        [Test]
+        public void When_ProviderControllerCreated_Expect_PutMethodWithTwoParameters()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Put";
+            var providerDTOParameter = "Stock.Api.DTOs.ProviderDTO, Stock.Api";
+            var parametersType = new Type[] { typeof(string), Type.GetType(providerDTOParameter) };
 
-//            Assert.True(HasMethod(className, methodName, parametersType));
-//        }
+            Assert.True(HasMethod(className, methodName, parametersType));
+        }
 
-//        [Test]
-//        public void When_ProviderControllerCreated_Expect_DeleteMethodWhitParameter()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Get";
-//            var parametersType = new Type[] { typeof(string) };
+        [Test]
+        public void When_ProviderControllerCreated_Expect_DeleteMethodWhitParameter()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Get";
+            var parametersType = new Type[] { typeof(string) };
 
-//            Assert.True(HasMethod(className, methodName, parametersType));
-//        }
+            Assert.True(HasMethod(className, methodName, parametersType));
+        }
 
-//        [Test]
-//        public void When_ProviderControllerCreated_Expect_SearchMethodWithParameter()
-//        {
-//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
-//            var methodName = "Search";
-//            var parametersType = new Type[] { typeof(ProviderSearchDTO) };
+        [Test]
+        public void When_ProviderControllerCreated_Expect_SearchMethodWithParameter()
+        {
+            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+            var methodName = "Search";
+            var providerSearchDTOParameter = "Stock.Api.DTOs.ProviderSearchDTO, Stock.Api";
+            var parametersType = new Type[] { Type.GetType(providerSearchDTOParameter) };
 
-//            Assert.True(HasMethod(className, methodName, parametersType));
-//        }
+            Assert.True(HasMethod(className, methodName, parametersType));
+        }
 
-//        private bool? HasMethod(string className, string methodName)
-//        {
-//            return Type.GetType(className).GetMethod(methodName, new Type[] { }) != null;
-//        }
+        private bool? HasMethod(string className, string methodName)
+        {
+            return Type.GetType(className).GetMethod(methodName, new Type[] { }) != null;
+        }
 
-//        private bool? HasMethod(string className, string methodName, Type[] types)
-//        {
-//            return Type.GetType(className).GetMethod(methodName, types) != null;
-//        }
-//    }
-//}
+        private bool? HasMethod(string className, string methodName, Type[] types)
+        {
+            return Type.GetType(className).GetMethod(methodName, types) != null;
+        }
+    }
+}

--- a/Stock.Test/ProviderControllerTests.cs
+++ b/Stock.Test/ProviderControllerTests.cs
@@ -1,0 +1,79 @@
+//using NUnit.Framework;
+//using Stock.Api.DTOs;
+//using System;
+
+//namespace Stock.Test
+//{
+//    public class ProviderControllerTests
+//    {
+//        [Test]
+//        public void When_ProvierControllerCreated_Expect_PostMethodWithParameter()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Post";
+//            var providerDTOParameter = "Stock.Api.DTOs.ProviderDTO, Stock.Api";
+//            var parametersType = new Type[] { Type.GetType(providerDTOParameter) };
+
+//            Assert.True(HasMethod(className, methodName, parametersType));
+//        }
+
+//        [Test]
+//        public void When_ProviderControllerCreated_Expect_GetMethodWhitParameter()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Get";
+//            var parametersType = new Type[] { typeof(string) };
+
+//            Assert.True(HasMethod(className, methodName, parametersType));
+//        }
+
+//        [Test]
+//        public void When_ProviderControllerCreated_Expect_GetMethodWhitoutParameter()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Get";
+
+//            Assert.True(HasMethod(className, methodName));
+//        }
+
+//        [Test]
+//        public void When_ProviderControllerCreated_Expect_PutMethodWithTwoParameters()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Put";
+//            var parametersType = new Type[] { typeof(string), typeof(ProviderDTO) };
+
+//            Assert.True(HasMethod(className, methodName, parametersType));
+//        }
+
+//        [Test]
+//        public void When_ProviderControllerCreated_Expect_DeleteMethodWhitParameter()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Get";
+//            var parametersType = new Type[] { typeof(string) };
+
+//            Assert.True(HasMethod(className, methodName, parametersType));
+//        }
+
+//        [Test]
+//        public void When_ProviderControllerCreated_Expect_SearchMethodWithParameter()
+//        {
+//            var className = "Stock.Api.Controllers.ProviderController, Stock.Api";
+//            var methodName = "Search";
+//            var parametersType = new Type[] { typeof(ProviderSearchDTO) };
+
+//            Assert.True(HasMethod(className, methodName, parametersType));
+//        }
+
+//        private bool? HasMethod(string className, string methodName)
+//        {
+//            return Type.GetType(className).GetMethod(methodName, new Type[] { }) != null;
+//        }
+
+//        private bool? HasMethod(string className, string methodName, Type[] types)
+//        {
+//            return Type.GetType(className).GetMethod(methodName, types) != null;
+//        }
+//    }
+//}

--- a/Stock.Test/Stock.Test.csproj
+++ b/Stock.Test/Stock.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stock.Api\Stock.Api.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Description

Se agregaron UnitTest para ProviderController. Estos sirven para controlar que los cambios de los participantes tengan la arquitectura especificada.
